### PR TITLE
perf: single chunk map

### DIFF
--- a/playground/js-sourcemap/__tests__/js-sourcemap.spec.ts
+++ b/playground/js-sourcemap/__tests__/js-sourcemap.spec.ts
@@ -143,7 +143,7 @@ describe.runIf(isBuild)('build tests', () => {
       {
         "debugId": "00000000-0000-0000-0000-000000000000",
         "ignoreList": [],
-        "mappings": ";+7BAAA,OAAO,2BAAuB,0BAE9B,QAAQ,IAAI,uBAAuB",
+        "mappings": "6gCAAA,OAAO,2BAAuB,SAE9B,QAAQ,IAAI,uBAAuB",
         "sources": [
           "../../after-preload-dynamic.js",
         ],
@@ -161,19 +161,6 @@ describe.runIf(isBuild)('build tests', () => {
     expect(js).toMatch(
       /\n\/\/# sourceMappingURL=after-preload-dynamic-[-\w]{8}\.js\.map\n$/,
     )
-  })
-
-  test('__vite__mapDeps injected after banner', async () => {
-    const js = findAssetFile(/after-preload-dynamic-hashbang-[-\w]{8}\.js$/)
-    expect(js.split('\n').slice(0, 2)).toEqual([
-      '#!/usr/bin/env node',
-      expect.stringContaining('const __vite__mapDeps=(i'),
-    ])
-  })
-
-  test('no unused __vite__mapDeps', async () => {
-    const js = findAssetFile(/after-preload-dynamic-no-dep-[-\w]{8}\.js$/)
-    expect(js).not.toMatch(/__vite__mapDeps/)
   })
 
   test('sourcemap is correct when using object as "define" value', async () => {


### PR DESCRIPTION
### Description
Previously, each chunk maintained its own registry mapping chunk paths to IDs for preloading, reducing string usage to save space. However, this registry was recreated for every chunk, even though a shared utility handled the actual preloading—which seemed like a more suitable place for this logic.

With this change, the chunk path-to-ID mapping is centralized in the shared preload method, eliminating duplicated chunk registries. I expect to see minor size improvements in apps that produce many chunks.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
